### PR TITLE
fix Windows component build

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -171,7 +171,7 @@ config("internal_config_base") {
 # This config should be applied to code using the libplatform.
 config("libplatform_config") {
   include_dirs = [ "include" ]
-  if (is_component_build) {
+  if (false) {
     defines = [ "USING_V8_PLATFORM_SHARED" ]
   }
 }
@@ -199,6 +199,7 @@ config("external_config") {
     defines = [
       "V8_SHARED",
       "USING_V8_SHARED",
+      "USING_V8_PLATFORM_SHARED",
     ]
   } else {
     defines = [


### PR DESCRIPTION
libplatform is forced to be built as a static library in NW.js, so USING_V8_PLATFORM_SHARED should not be defined for its direct dependents. Instead, the macro should be defined at the same place as USING_V8_SHARED since libplatform is part of the main V8 library now.

Refs: nwjs/nw.js#6172
